### PR TITLE
fixed add-ticket exception in shared layout bar

### DIFF
--- a/Team4_FinalProject/Team4_FinalProject/Views/Shared/_Layout.cshtml
+++ b/Team4_FinalProject/Team4_FinalProject/Views/Shared/_Layout.cshtml
@@ -21,19 +21,20 @@
                         <li class="nav-item">
                             <a class="nav-link text-light" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-light" asp-area="" asp-controller="Ticket" asp-action="Add" asp-route-id="@TempData["userId"]">Add Ticket</a>
-                        </li>
-                        @if (ViewData["User"] == null)
+
+                        @if (ViewData["User"] != null)
                         {
                             <li class="nav-item">
-                                <a class="nav-link text-light" asp-area="" asp-controller="Login" asp-action="Index">Log In</a>
+                                <a class="nav-link text-light" asp-area="" asp-controller="Ticket" asp-action="Add" asp-route-id="@TempData["userId"]">Add Ticket</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link text-light" asp-area="" asp-controller="Login" asp-action="Logout">Log Out</a>
                             </li>
                         }
                         else
                         {
                             <li class="nav-item">
-                                <a class="nav-link text-light" asp-area="" asp-controller="Login" asp-action="Logout">Log Out</a>
+                                <a class="nav-link text-light" asp-area="" asp-controller="Login" asp-action="Index">Log In</a>
                             </li>
                         }
                     </ul>


### PR DESCRIPTION
_Layout.cshtml used to show add-ticket when a user wasn't logged in, which resulted in a null exception on the add-ticket page. Changed layout so that isn't a possibility